### PR TITLE
Add support for named sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ The rule will be a `concat::fragment` to the chain
 `CHAIN_NAME`.
 
 You can define the order by using the `order` param.
+
+## nftsables::set
+
+Adds a named set to a given table. It allows composing the
+set using individual parameters but also takes raw input
+via the content and source parameters.

--- a/files/config/puppet-inet-filter.nft
+++ b/files/config/puppet-inet-filter.nft
@@ -1,4 +1,3 @@
-table inet filter {
   include "/etc/nftables/puppet/inet-filter-chain-*.nft"
 
   # something we want for all
@@ -11,4 +10,3 @@ table inet filter {
     ip protocol icmp icmp type echo-request limit rate 4/second accept
     ip6 nexthdr ipv6-icmp icmpv6 type echo-request limit rate 4/second accept
   }
-}

--- a/files/config/puppet-ip-nat.nft
+++ b/files/config/puppet-ip-nat.nft
@@ -1,3 +1,1 @@
-table ip nat {
   include "/etc/nftables/puppet/ip-nat-chain-*.nft"
-}

--- a/files/config/puppet-ip6-nat.nft
+++ b/files/config/puppet-ip6-nat.nft
@@ -1,3 +1,1 @@
-table ip6 nat {
   include "/etc/nftables/puppet/ip6-nat-chain-*.nft"
-}

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -1,0 +1,72 @@
+# manage a named set
+define nftables::set(
+  Enum['ipv4_addr', 'ipv6_addr', 'ether_addr', 'inet_proto', 'inet_service', 'mark']
+    $type,
+  Enum['present','absent']
+    $ensure = 'present',
+  Pattern[/^[a-zA-Z0-9_]+$/]
+    $setname = $title,
+  Pattern[/^\d\d$/]
+    $order = '10',
+  String
+    $table = 'inet-filter',
+  Array[Enum['constant', 'dynamic', 'interval', 'timeout'], 0, 4]
+    $flags = [],
+  Optional[Integer]
+    $timeout = undef,
+  Optional[Integer]
+    $gc_interval = undef,
+  Optional[Array[String]]
+    $elements = undef,
+  Optional[Integer]
+    $size = undef,
+  Optional[Enum['performance', 'memory']]
+    $policy = undef,
+  Boolean
+    $auto_merge = false,
+  Optional[String]
+    $content = undef,
+  Optional[Variant[String,Array[String,1]]]
+    $source = undef,
+){
+
+  if $size and $elements {
+    if length($elements) > $size {
+      fail("Max size of set ${setname} of ${size} is not being respected")
+    }
+  }
+
+  if $ensure == 'present' {
+    concat::fragment{
+      "nftables-${table}-set-${setname}":
+        order  => $order,
+        target => "nftables-${table}",
+    }
+
+    if $content {
+      Concat::Fragment["nftables-${table}-set-${setname}"]{
+        content => "  ${content}",
+      }
+    } elsif $source {
+      Concat::Fragment["nftables-${table}-set-${setname}"]{
+        source => $source,
+      }
+    } else {
+      Concat::Fragment["nftables-${table}-set-${setname}"]{
+        content => epp('nftables/set.epp',
+          {
+            'name'        => $setname,
+            'type'        => $type,
+            'flags'       => $flags,
+            'timeout'     => $timeout,
+            'gc_interval' => $gc_interval,
+            'elements'    => $elements,
+            'size'        => $size,
+            'policy'      => $policy,
+            'auto_merge'  => $auto_merge,
+          }
+        )
+      }
+    }
+  }
+}

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -10,11 +10,35 @@ describe 'nftables' do
       it { is_expected.to compile }
 
       it {
-        is_expected.to contain_file('/etc/nftables/puppet/inet-filter.nft').with(
-          ensure: 'file',
+        is_expected.to contain_concat('nftables-inet-filter').with(
+          path:   '/etc/nftables/puppet/inet-filter.nft',
+          ensure: 'present',
           owner:  'root',
           group:  'root',
           mode:   '0640',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat__fragment('nftables-inet-filter-header').with(
+          target:  'nftables-inet-filter',
+          content: %r{^table inet filter \{$},
+          order:   '00',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat__fragment('nftables-inet-filter-body').with(
+          target:  'nftables-inet-filter',
+          order:   '98',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat__fragment('nftables-inet-filter-footer').with(
+          target:  'nftables-inet-filter',
+          content: %r{^\}$},
+          order:   '99',
         )
       }
 

--- a/spec/classes/ip_nat_spec.rb
+++ b/spec/classes/ip_nat_spec.rb
@@ -10,8 +10,9 @@ describe 'nftables' do
       it { is_expected.to compile }
 
       it {
-        is_expected.to contain_file('/etc/nftables/puppet/ip-nat.nft').with(
-          ensure: 'file',
+        is_expected.to contain_concat('nftables-ip-nat').with(
+          path:   '/etc/nftables/puppet/ip-nat.nft',
+          ensure: 'present',
           owner:  'root',
           group:  'root',
           mode:   '0640',
@@ -19,11 +20,58 @@ describe 'nftables' do
       }
 
       it {
-        is_expected.to contain_file('/etc/nftables/puppet/ip6-nat.nft').with(
-          ensure: 'file',
+        is_expected.to contain_concat__fragment('nftables-ip-nat-header').with(
+          target:  'nftables-ip-nat',
+          content: %r{^table ip nat \{$},
+          order:   '00',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat__fragment('nftables-ip-nat-body').with(
+          target:  'nftables-ip-nat',
+          order:   '98',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat__fragment('nftables-ip-nat-footer').with(
+          target:  'nftables-ip-nat',
+          content: %r{^\}$},
+          order:   '99',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat('nftables-ip6-nat').with(
+          path:   '/etc/nftables/puppet/ip6-nat.nft',
+          ensure: 'present',
           owner:  'root',
           group:  'root',
           mode:   '0640',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat__fragment('nftables-ip6-nat-header').with(
+          target:  'nftables-ip6-nat',
+          content: %r{^table ip6 nat \{$},
+          order:   '00',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat__fragment('nftables-ip6-nat-body').with(
+          target:  'nftables-ip6-nat',
+          order:   '98',
+        )
+      }
+
+      it {
+        is_expected.to contain_concat__fragment('nftables-ip6-nat-footer').with(
+          target:  'nftables-ip6-nat',
+          content: %r{^\}$},
+          order:   '99',
         )
       }
 

--- a/templates/set.epp
+++ b/templates/set.epp
@@ -1,0 +1,34 @@
+<%- | String                  $name,
+      String                  $type,
+      Array                   $flags,
+      Optional[Integer]       $timeout,
+      Optional[Integer]       $gc_interval,
+      Optional[Array[String]] $elements,
+      Optional[Integer]       $size,
+      Optional[String]        $policy,
+      Boolean                 $auto_merge,
+| -%>
+  set <%= $name %> {
+    type <%= $type %>
+    <%- if $flags and length($flags) > 0 { -%>
+    flags <%= $flags.join(', ') %>
+    <%- } -%>
+    <%- if $timeout { -%>
+    timeout <%= $timeout %>
+    <%- } -%>
+    <%- if $gc_interval { -%>
+    gc-interval <%= $gc_interval %>
+    <%- } -%>
+    <%- if $elements and length($elements) > 0 { -%>
+    elements = { <%= $elements.join(', ') %> }
+    <%- } -%>
+    <%- if $size { -%>
+    size <%= $size %>
+    <%- } -%>
+    <%- if $policy { -%>
+    policy <%= $policy %>
+    <%- } -%>
+    <%- if $auto_merge { -%>
+    auto-merge
+    <%- } -%>
+  }


### PR DESCRIPTION
This patchset adds a new type that allows defining named sets that can be used in rules, for example:

```puppet
  nftables::set{
    'foo_set':
      type       => 'ipv4_addr',
      flags      => ['interval'],
      elements   => ['192.168.0.1/24', '192.168.1.2'],
      auto_merge => true,
  }

  nftables::rule{
    'default_in-5000':
      content => "tcp dport {5000} ip saddr @foo_set accept",
      require => Nftables::Set['foo_set'],
  }
```