### PR TITLE
Allow customising the log prefix

### DIFF
--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -39,7 +39,7 @@ class nftables::inet_filter inherits nftables {
       content => 'jump global';
     'INPUT-log_rejected':
       order   => '98',
-      content => 'log prefix "[nftables] INPUT Rejected: " flags all counter reject with icmpx type port-unreachable';
+      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'INPUT' })}\" flags all counter reject with icmpx type port-unreachable";
   }
 
   # inet-filter-chain-OUTPUT
@@ -58,7 +58,7 @@ class nftables::inet_filter inherits nftables {
       content => 'jump global';
     'OUTPUT-log_rejected':
       order   => '98',
-      content => 'log prefix "[nftables] OUTPUT Rejected: " flags all counter reject with icmpx type port-unreachable';
+      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'OUTPUT' })}\" flags all counter reject with icmpx type port-unreachable";
   }
 
   # inet-filter-chain-FORWARD
@@ -74,7 +74,7 @@ class nftables::inet_filter inherits nftables {
       content => 'jump global';
     'FORWARD-log_rejected':
       order   => '98',
-      content => 'log prefix "[nftables] FORWARD Rejected: " flags all counter reject with icmpx type port-unreachable';
+      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'FORWARD' })}\" flags all counter reject with icmpx type port-unreachable";
   }
 
   # basic outgoing rules

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class nftables (
   Boolean $out_https = true,
   Boolean $out_all   = false,
   Hash $rules        = {},
+  String $log_prefix = '[nftables] %<chain>s Rejected: ',
 ) {
 
   package{'nftables':

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -328,6 +328,58 @@ describe 'nftables' do
           )
         }
       end
+
+      context 'custom log prefix without variable substitution' do
+        let(:pre_condition) { 'class{\'nftables\': log_prefix => "test "}' }
+
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_rejected').with(
+            target:  'nftables-inet-filter-chain-INPUT',
+            content: %r{^  log prefix \"test " flags all counter reject with icmpx type port-unreachable$},
+            order:   '98',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_rejected').with(
+            target:  'nftables-inet-filter-chain-OUTPUT',
+            content: %r{^  log prefix \"test " flags all counter reject with icmpx type port-unreachable$},
+            order:   '98',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_rejected').with(
+            target:  'nftables-inet-filter-chain-FORWARD',
+            content: %r{^  log prefix \"test " flags all counter reject with icmpx type port-unreachable$},
+            order:   '98',
+          )
+        }
+      end
+
+      context 'custom log prefix with variable substitution' do
+        let(:pre_condition) { 'class{\'nftables\': log_prefix => " bar [%<chain>s] "}' } # rubocop:disable Style/FormatStringToken
+
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_rejected').with(
+            target:  'nftables-inet-filter-chain-INPUT',
+            content: %r{^  log prefix \" bar \[INPUT\] " flags all counter reject with icmpx type port-unreachable$},
+            order:   '98',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_rejected').with(
+            target:  'nftables-inet-filter-chain-OUTPUT',
+            content: %r{^  log prefix \" bar \[OUTPUT\] " flags all counter reject with icmpx type port-unreachable$},
+            order:   '98',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_rejected').with(
+            target:  'nftables-inet-filter-chain-FORWARD',
+            content: %r{^  log prefix \" bar \[FORWARD\] " flags all counter reject with icmpx type port-unreachable$},
+            order:   '98',
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
This patch partly implements #2, allowing the caller of the module to configure the prefix that's used to log when packets reach the end of the chains. Perhaps the default values of the parameters of the `nftables` class should be moved to module-level Hiera data (`data/common.yaml`) to make it cleaner.