### PR TITLE
Add rules for afs3_callback in and out rules for kerberos and openafs.

### DIFF
--- a/manifests/rules/afs3_callback.pp
+++ b/manifests/rules/afs3_callback.pp
@@ -1,0 +1,16 @@
+# @summary Open call back port for AFS clients
+# @param saddr list of source network ranges to a
+# @example
+# class{'nftables::rules::afs3_callback':
+#   saddr => ['192.168.0.0/16', '10.0.0.222']
+# }
+#
+class nftables::rules::afs3_callback (
+  Array[Stdlib::IP::Address::V4,1] $saddr = ['0.0.0.0/0'],
+) {
+
+  nftables::rule{'default_in-afs3_callback':
+    content =>  "ip saddr { ${saddr.join(', ')} } udp dport 7001 accept";
+  }
+
+}

--- a/manifests/rules/out/kerberos.pp
+++ b/manifests/rules/out/kerberos.pp
@@ -1,0 +1,11 @@
+# @summary allows outbound access for kerberos
+class nftables::rules::out::kerberos {
+
+  nftables::rule{
+    'default_out-kerberos_udp':
+       content =>  'udp dport 88 accept';
+    'default_out-kerberos_tcp':
+       content =>  'tcp dport 88 accept';
+  }
+
+}

--- a/manifests/rules/out/kerberos.pp
+++ b/manifests/rules/out/kerberos.pp
@@ -3,9 +3,9 @@ class nftables::rules::out::kerberos {
 
   nftables::rule{
     'default_out-kerberos_udp':
-       content =>  'udp dport 88 accept';
+      content =>  'udp dport 88 accept';
     'default_out-kerberos_tcp':
-       content =>  'tcp dport 88 accept';
+      content =>  'tcp dport 88 accept';
   }
 
 }

--- a/manifests/rules/out/openafs_client.pp
+++ b/manifests/rules/out/openafs_client.pp
@@ -1,0 +1,18 @@
+# @summary allows outbound access for afs clients
+# 7000 - afs3-fileserver
+# 7002 - afs3-ptserver
+# 7003 - vlserver
+#
+# @see https://wiki.openafs.org/devel/AFSServicePorts/ AFS Service Ports
+#
+class nftables::rules::out::openafs_client(
+  Array[Integer,1] $ports = [7000, 7002, 7003],
+){
+
+  include nftables::rules::out::kerberos
+
+  nftables::rule{'default_out-openafs_client':
+    content => "udp dport {${$ports.join(', ')}} accept";
+  }
+
+}

--- a/manifests/services/openafs_client.pp
+++ b/manifests/services/openafs_client.pp
@@ -1,0 +1,8 @@
+class nftables::services::openafs_client inherits nftables {
+  if $nftables::out_all {
+    fail('All outgoing traffic is allowed, you might want to use only nftables::rules::afs3_callback')
+  }
+
+  include nftables::rules::afs3_callback
+  include nftables::rules::out::openafs_client
+}

--- a/spec/classes/rules/afs3_callback_spec.rb
+++ b/spec/classes/rules/afs3_callback_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'nftables::rules::afs3_callback' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-afs3_callback') }
+        it { is_expected.to contain_nftables__rule('default_in-afs3_callback').with_content('ip saddr { 0.0.0.0/0 } udp dport 7001 accept') }
+      end
+
+      context 'with saddr set' do
+        let(:params) do
+          {
+            saddr: ['192.168.0.0/16', '1.2.3.4'],
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_in-afs3_callback') }
+        it { is_expected.to contain_nftables__rule('default_in-afs3_callback').with_content('ip saddr { 192.168.0.0/16, 1.2.3.4 } udp dport 7001 accept') }
+      end
+    end
+  end
+end

--- a/spec/classes/rules/out/kerberos_spec.rb
+++ b/spec/classes/rules/out/kerberos_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'nftables::rules::out::kerberos' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_out-kerberos_udp').with_content('udp dport 88 accept') }
+        it { is_expected.to contain_nftables__rule('default_out-kerberos_tcp').with_content('tcp dport 88 accept') }
+      end
+    end
+  end
+end

--- a/spec/classes/rules/out/openafs_client_spec.rb
+++ b/spec/classes/rules/out/openafs_client_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'nftables::rules::out::openafs_client' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_out-openafs_client').with_content('udp dport {7000, 7002, 7003} accept') }
+      end
+
+      context 'with ports set' do
+        let(:params) do
+          {
+            ports: [7000, 7002],
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_nftables__rule('default_out-openafs_client').with_content('udp dport {7000, 7002} accept') }
+      end
+    end
+  end
+end

--- a/spec/classes/services/openafs_client_spec.rb
+++ b/spec/classes/services/openafs_client_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'nftables::services::openafs_client' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'normal behaviour' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_class('nftables::rules::afs3_callback') }
+        it { is_expected.to contain_class('nftables::rules::out::openafs_client') }
+      end
+
+      context 'out_all enabled' do
+        let(:pre_condition) { 'class{\'nftables\': out_all => true}' }
+
+        it { is_expected.not_to compile }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the afs callback to the cache manager(7001) which is UDP and always
IPv4 since there OpenAFS does not support IPv6.

```puppet
include nftables::rules::afs3_callback
```

For background OpenAFS servers connect to clients on the `afs3_callback` port and it is the server
initiating the connection. The clients have already connected to server on a completely different ports.

To configure an openafs client in totality 

```puppet
include nftables::services::openafs_client
```
which will allow both outbound connections clients need and the inbound cache callbacks. 

https://wiki.openafs.org/devel/AFSServicePorts/