### PR TITLE
Add a parameter to control the fate of discarded traffic

### DIFF
--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -37,9 +37,16 @@ class nftables::inet_filter inherits nftables {
     'INPUT-jump_global':
       order   => '04',
       content => 'jump global';
-    'INPUT-log_rejected':
-      order   => '98',
-      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'INPUT' })}\" flags all counter reject with icmpx type port-unreachable";
+    'INPUT-log_discarded':
+      order   => '97',
+      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'INPUT' })}\" flags all counter";
+  }
+  if $nftables::reject_with {
+    nftables::rule{
+      'INPUT-reject':
+        order   => '98',
+        content => "reject with ${$nftables::reject_with}";
+    }
   }
 
   # inet-filter-chain-OUTPUT
@@ -56,9 +63,16 @@ class nftables::inet_filter inherits nftables {
     'OUTPUT-jump_global':
       order   => '04',
       content => 'jump global';
-    'OUTPUT-log_rejected':
-      order   => '98',
-      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'OUTPUT' })}\" flags all counter reject with icmpx type port-unreachable";
+    'OUTPUT-log_discarded':
+      order   => '97',
+      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'OUTPUT' })}\" flags all counter";
+  }
+  if $nftables::reject_with {
+    nftables::rule{
+      'OUTPUT-reject':
+        order   => '98',
+        content => "reject with ${$nftables::reject_with}";
+    }
   }
 
   # inet-filter-chain-FORWARD
@@ -72,9 +86,16 @@ class nftables::inet_filter inherits nftables {
     'FORWARD-jump_global':
       order   => '03',
       content => 'jump global';
-    'FORWARD-log_rejected':
-      order   => '98',
-      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'FORWARD' })}\" flags all counter reject with icmpx type port-unreachable";
+    'FORWARD-log_discarded':
+      order   => '97',
+      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'FORWARD' })}\" flags all counter";
+  }
+  if $nftables::reject_with {
+    nftables::rule{
+      'FORWARD-reject':
+        order   => '98',
+        content => "reject with ${$nftables::reject_with}";
+    }
   }
 
   # basic outgoing rules

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,15 +26,24 @@
 # @param in_ssh
 #   Allow inbound to ssh servers.
 #
+# @param reject_with
+#   How to discard packets not matching any rule. If `false`, the
+#   fate of the packet will be defined by the chain policy (normally
+#   drop), otherwise the packet will be rejected with the REJECT_WITH
+#   policy indicated by the value of this parameter.
+#
 class nftables (
-  Boolean $in_ssh    = true,
-  Boolean $out_ntp   = true,
-  Boolean $out_dns   = true,
-  Boolean $out_http  = true,
-  Boolean $out_https = true,
-  Boolean $out_all   = false,
-  Hash $rules        = {},
-  String $log_prefix = '[nftables] %<chain>s Rejected: ',
+  Boolean $in_ssh                = true,
+  Boolean $out_ntp               = true,
+  Boolean $out_dns               = true,
+  Boolean $out_http              = true,
+  Boolean $out_https             = true,
+  Boolean $out_all               = false,
+  Hash $rules                    = {},
+  String $log_prefix             = '[nftables] %<chain>s Rejected: ',
+  Variant[Boolean[false], Pattern[
+    /icmp(v6|x)? type .+|tcp reset/]]
+    $reject_with                 = 'icmpx type port-unreachable',
 ) {
 
   package{'nftables':

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -95,9 +95,16 @@ describe 'nftables' do
           )
         }
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_rejected').with(
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-INPUT',
-            content: %r{^  log prefix \"\[nftables\] INPUT Rejected: \" flags all counter reject with icmpx type port-unreachable$},
+            content: %r{^  log prefix \"\[nftables\] INPUT Rejected: \" flags all counter$},
+            order:   '97',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-reject').with(
+            target:  'nftables-inet-filter-chain-INPUT',
+            content: %r{^  reject with icmpx type port-unreachable$},
             order:   '98',
           )
         }
@@ -194,9 +201,16 @@ describe 'nftables' do
           )
         }
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_rejected').with(
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-OUTPUT',
-            content: %r{^  log prefix \"\[nftables\] OUTPUT Rejected: \" flags all counter reject with icmpx type port-unreachable$},
+            content: %r{^  log prefix \"\[nftables\] OUTPUT Rejected: \" flags all counter$},
+            order:   '97',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-reject').with(
+            target:  'nftables-inet-filter-chain-OUTPUT',
+            content: %r{^  reject with icmpx type port-unreachable$},
             order:   '98',
           )
         }
@@ -314,9 +328,16 @@ describe 'nftables' do
           )
         }
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_rejected').with(
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-FORWARD',
-            content: %r{^  log prefix \"\[nftables\] FORWARD Rejected: \" flags all counter reject with icmpx type port-unreachable$},
+            content: %r{^  log prefix \"\[nftables\] FORWARD Rejected: \" flags all counter$},
+            order:   '97',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-reject').with(
+            target:  'nftables-inet-filter-chain-FORWARD',
+            content: %r{^  reject with icmpx type port-unreachable$},
             order:   '98',
           )
         }
@@ -357,24 +378,24 @@ describe 'nftables' do
         let(:pre_condition) { 'class{\'nftables\': log_prefix => "test "}' }
 
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_rejected').with(
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-INPUT',
-            content: %r{^  log prefix \"test " flags all counter reject with icmpx type port-unreachable$},
-            order:   '98',
+            content: %r{^  log prefix \"test " flags all counter$},
+            order:   '97',
           )
         }
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_rejected').with(
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-OUTPUT',
-            content: %r{^  log prefix \"test " flags all counter reject with icmpx type port-unreachable$},
-            order:   '98',
+            content: %r{^  log prefix \"test " flags all counter$},
+            order:   '97',
           )
         }
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_rejected').with(
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-FORWARD',
-            content: %r{^  log prefix \"test " flags all counter reject with icmpx type port-unreachable$},
-            order:   '98',
+            content: %r{^  log prefix \"test " flags all counter$},
+            order:   '97',
           )
         }
       end
@@ -383,26 +404,93 @@ describe 'nftables' do
         let(:pre_condition) { 'class{\'nftables\': log_prefix => " bar [%<chain>s] "}' } # rubocop:disable Style/FormatStringToken
 
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_rejected').with(
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-INPUT',
-            content: %r{^  log prefix \" bar \[INPUT\] " flags all counter reject with icmpx type port-unreachable$},
-            order:   '98',
+            content: %r{^  log prefix \" bar \[INPUT\] " flags all counter$},
+            order:   '97',
           )
         }
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_rejected').with(
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-OUTPUT',
-            content: %r{^  log prefix \" bar \[OUTPUT\] " flags all counter reject with icmpx type port-unreachable$},
+            content: %r{^  log prefix \" bar \[OUTPUT\] " flags all counter$},
+            order:   '97',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_discarded').with(
+            target:  'nftables-inet-filter-chain-FORWARD',
+            content: %r{^  log prefix \" bar \[FORWARD\] " flags all counter$},
+            order:   '97',
+          )
+        }
+      end
+
+      context 'no reject rule, use chain policy without explicit reject' do
+        let(:params) do
+          {
+            'reject_with' => false,
+          }
+        end
+
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_discarded')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-reject')
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_discarded')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-reject')
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_discarded')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-reject')
+        }
+      end
+
+      context 'custom reject configuration is allowed' do
+        let(:params) do
+          {
+            'reject_with' => 'tcp reset',
+          }
+        end
+
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-reject').with(
+            target:  'nftables-inet-filter-chain-INPUT',
+            content: %r{^  reject with tcp reset$},
             order:   '98',
           )
         }
         it {
-          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_rejected').with(
-            target:  'nftables-inet-filter-chain-FORWARD',
-            content: %r{^  log prefix \" bar \[FORWARD\] " flags all counter reject with icmpx type port-unreachable$},
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-reject').with(
+            target:  'nftables-inet-filter-chain-OUTPUT',
+            content: %r{^  reject with tcp reset$},
             order:   '98',
           )
         }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-reject').with(
+            target:  'nftables-inet-filter-chain-FORWARD',
+            content: %r{^  reject with tcp reset$},
+            order:   '98',
+          )
+        }
+      end
+
+      context 'fails with unvalid reject with' do
+        let(:params) do
+          {
+            'reject_with' => true,
+          }
+        end
+
+        it { is_expected.not_to compile }
       end
     end
   end


### PR DESCRIPTION
This patch implements the second feature requested via #2, adding a parameter to configure how discarded packets will be handled. By default, they'll be rejected by the last rule in each chain with `icmpx type port-unreachable` as it's always been, however it's possible now to set the parameter to `false` so the packets are handled instead via the policies of the chains which at the moment are all `drop`.

Closes #2. 