### PR TITLE
Allow raw sets and dashes in set names

### DIFF
--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -2,7 +2,7 @@
 define nftables::set(
   Enum['present','absent']
     $ensure = 'present',
-  Pattern[/^[a-zA-Z0-9_]+$/]
+  Pattern[/^[-a-zA-Z0-9_]+$/]
     $setname = $title,
   Pattern[/^\d\d$/]
     $order = '10',

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -1,13 +1,13 @@
 # manage a named set
 define nftables::set(
-  Enum['ipv4_addr', 'ipv6_addr', 'ether_addr', 'inet_proto', 'inet_service', 'mark']
-    $type,
   Enum['present','absent']
     $ensure = 'present',
   Pattern[/^[a-zA-Z0-9_]+$/]
     $setname = $title,
   Pattern[/^\d\d$/]
     $order = '10',
+  Optional[Enum['ipv4_addr', 'ipv6_addr', 'ether_addr', 'inet_proto', 'inet_service', 'mark']]
+    $type = undef,
   String
     $table = 'inet-filter',
   Array[Enum['constant', 'dynamic', 'interval', 'timeout'], 0, 4]
@@ -52,6 +52,9 @@ define nftables::set(
         source => $source,
       }
     } else {
+      if $type == undef {
+        fail('The way the resource is configured must have a type set')
+      }
       Concat::Fragment["nftables-${table}-set-${setname}"]{
         content => epp('nftables/set.epp',
           {

--- a/spec/defines/set_spec.rb
+++ b/spec/defines/set_spec.rb
@@ -136,6 +136,24 @@ describe 'nftables::set' do
       describe 'fails without a type and not source/content' do
         it { is_expected.not_to compile }
       end
+
+      describe 'set names with dashes are allowed' do
+        let(:title) { 'my-set' }
+        let(:params) do
+          {
+            type: 'ether_addr',
+          }
+        end
+
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-set-my-set').with(
+            target:  'nftables-inet-filter',
+            content: %r{^  set my-set \{\n    type ether_addr\n  \}$}m,
+            order:   '10',
+          )
+        }
+      end
     end
   end
 end

--- a/spec/defines/set_spec.rb
+++ b/spec/defines/set_spec.rb
@@ -115,6 +115,27 @@ describe 'nftables::set' do
           )
         }
       end
+
+      describe 'using raw content' do
+        let(:params) do
+          {
+            content: 'set my_set { }',
+          }
+        end
+
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-set-my_set').with(
+            target:  'nftables-inet-filter',
+            content: '  set my_set { }',
+            order:   '10',
+          )
+        }
+      end
+
+      describe 'fails without a type and not source/content' do
+        it { is_expected.not_to compile }
+      end
     end
   end
 end


### PR DESCRIPTION
This patchset does two things:

* Relax the parameter `type` of the defined type `nftables::set` so it does not have to be always set, allowing to define a set passing raw input using `source` or `content` (see tests)
* Allow dashes to be part of set names.