### PR TITLE
Allow tables to add comments to $log_prefix

### DIFF
--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -1,6 +1,8 @@
 # manage basic chains in table inet filter
 class nftables::inet_filter inherits nftables {
 
+  $_log_prefix_discard = sprintf($nftables::log_prefix, { 'chain' => '%<chain>s', 'comment' => 'Rejected: ' })
+
   nftables::config{
     'inet-filter':
       source => 'puppet:///modules/nftables/config/puppet-inet-filter.nft';
@@ -39,7 +41,7 @@ class nftables::inet_filter inherits nftables {
       content => 'jump global';
     'INPUT-log_discarded':
       order   => '97',
-      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'INPUT' })}\" flags all counter";
+      content => "log prefix \"${sprintf($_log_prefix_discard, { 'chain' => 'INPUT' })}\" flags all counter";
   }
   if $nftables::reject_with {
     nftables::rule{
@@ -65,7 +67,7 @@ class nftables::inet_filter inherits nftables {
       content => 'jump global';
     'OUTPUT-log_discarded':
       order   => '97',
-      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'OUTPUT' })}\" flags all counter";
+      content => "log prefix \"${sprintf($_log_prefix_discard, { 'chain' => 'OUTPUT' })}\" flags all counter";
   }
   if $nftables::reject_with {
     nftables::rule{
@@ -88,7 +90,7 @@ class nftables::inet_filter inherits nftables {
       content => 'jump global';
     'FORWARD-log_discarded':
       order   => '97',
-      content => "log prefix \"${sprintf($nftables::log_prefix, { 'chain' => 'FORWARD' })}\" flags all counter";
+      content => "log prefix \"${sprintf($_log_prefix_discard, { 'chain' => 'FORWARD' })}\" flags all counter";
   }
   if $nftables::reject_with {
     nftables::rule{

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,12 @@
 # @param in_ssh
 #   Allow inbound to ssh servers.
 #
+# @param log_prefix
+#   String that will be used as prefix when logging packets. It can contain
+#   two variables using standard sprintf() string-formatting:
+#    * chain: Will be replaced by the name of the chain.
+#    * comment: Allows chains to add extra comments.
+#
 # @param reject_with
 #   How to discard packets not matching any rule. If `false`, the
 #   fate of the packet will be defined by the chain policy (normally
@@ -40,7 +46,7 @@ class nftables (
   Boolean $out_https             = true,
   Boolean $out_all               = false,
   Hash $rules                    = {},
-  String $log_prefix             = '[nftables] %<chain>s Rejected: ',
+  String $log_prefix             = '[nftables] %<chain>s %<comment>s',
   Variant[Boolean[false], Pattern[
     /icmp(v6|x)? type .+|tcp reset/]]
     $reject_with                 = 'icmpx type port-unreachable',

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -375,52 +375,60 @@ describe 'nftables' do
       end
 
       context 'custom log prefix without variable substitution' do
-        let(:pre_condition) { 'class{\'nftables\': log_prefix => "test "}' }
+        let(:params) do
+          {
+            'log_prefix' => 'test',
+          }
+        end
 
         it {
           is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-INPUT',
-            content: %r{^  log prefix \"test " flags all counter$},
+            content: %r{^  log prefix "test" flags all counter$},
             order:   '97',
           )
         }
         it {
           is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-OUTPUT',
-            content: %r{^  log prefix \"test " flags all counter$},
+            content: %r{^  log prefix "test" flags all counter$},
             order:   '97',
           )
         }
         it {
           is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-FORWARD',
-            content: %r{^  log prefix \"test " flags all counter$},
+            content: %r{^  log prefix "test" flags all counter$},
             order:   '97',
           )
         }
       end
 
       context 'custom log prefix with variable substitution' do
-        let(:pre_condition) { 'class{\'nftables\': log_prefix => " bar [%<chain>s] "}' } # rubocop:disable Style/FormatStringToken
+        let(:params) do
+          {
+            'log_prefix' => ' bar [%<chain>s] ', # rubocop:disable Style/FormatStringToken
+          }
+        end
 
         it {
           is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-INPUT',
-            content: %r{^  log prefix \" bar \[INPUT\] " flags all counter$},
+            content: %r{^  log prefix " bar \[INPUT\] " flags all counter$},
             order:   '97',
           )
         }
         it {
           is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-OUTPUT',
-            content: %r{^  log prefix \" bar \[OUTPUT\] " flags all counter$},
+            content: %r{^  log prefix " bar \[OUTPUT\] " flags all counter$},
             order:   '97',
           )
         }
         it {
           is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-log_discarded').with(
             target:  'nftables-inet-filter-chain-FORWARD',
-            content: %r{^  log prefix \" bar \[FORWARD\] " flags all counter$},
+            content: %r{^  log prefix " bar \[FORWARD\] " flags all counter$},
             order:   '97',
           )
         }


### PR DESCRIPTION
This patchset implements the changes suggested on [#7](https://github.com/duritong/puppet-nftables/pull/7#discussion_r525215978) by @keachi 