### PR TITLE
Move conntrack rules from global to INPUT and OUTPUT

### DIFF
--- a/files/config/puppet-inet-filter.nft
+++ b/files/config/puppet-inet-filter.nft
@@ -2,9 +2,6 @@
 
   # something we want for all
   chain global {
-    ct state established,related accept
-    ct state invalid drop
-
     ip protocol icmp icmp type { destination-unreachable, time-exceeded, parameter-problem } accept
     ip6 nexthdr ipv6-icmp icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, mld-listener-query, mld-listener-report, mld-listener-done, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, ind-neighbor-solicit, ind-neighbor-advert, mld2-listener-report } accept
     ip protocol icmp icmp type echo-request limit rate 4/second accept

--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -50,6 +50,16 @@ class nftables::inet_filter inherits nftables {
         content => "reject with ${$nftables::reject_with}";
     }
   }
+  if $nftables::in_out_conntrack {
+    nftables::rule{
+      'INPUT-accept_established_related':
+        order   => '05',
+        content => 'ct state established,related accept';
+      'INPUT-drop_invalid':
+        order   => '06',
+        content => 'ct state invalid drop';
+    }
+  }
 
   # inet-filter-chain-OUTPUT
   nftables::rule{
@@ -74,6 +84,16 @@ class nftables::inet_filter inherits nftables {
       'OUTPUT-reject':
         order   => '98',
         content => "reject with ${$nftables::reject_with}";
+    }
+  }
+  if $nftables::in_out_conntrack {
+    nftables::rule{
+      'OUTPUT-accept_established_related':
+        order   => '05',
+        content => 'ct state established,related accept';
+      'OUTPUT-drop_invalid':
+        order   => '06',
+        content => 'ct state invalid drop';
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,10 @@
 #   drop), otherwise the packet will be rejected with the REJECT_WITH
 #   policy indicated by the value of this parameter.
 #
+# @param in_out_conntrack
+#   Adds INPUT and OUTPUT rules to allow traffic that's part of an
+#   established connection and also to drop invalid packets.
+#
 class nftables (
   Boolean $in_ssh                = true,
   Boolean $out_ntp               = true,
@@ -45,6 +49,7 @@ class nftables (
   Boolean $out_http              = true,
   Boolean $out_https             = true,
   Boolean $out_all               = false,
+  Boolean $in_out_conntrack      = true,
   Hash $rules                    = {},
   String $log_prefix             = '[nftables] %<chain>s %<comment>s',
   Variant[Boolean[false], Pattern[

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -88,6 +88,20 @@ describe 'nftables' do
           )
         }
         it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-accept_established_related').with(
+            target:  'nftables-inet-filter-chain-INPUT',
+            content: %r{^  ct state established,related accept$},
+            order:   '05',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-drop_invalid').with(
+            target:  'nftables-inet-filter-chain-INPUT',
+            content: %r{^  ct state invalid drop$},
+            order:   '06',
+          )
+        }
+        it {
           is_expected.to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-jump_default_in').with(
             target:  'nftables-inet-filter-chain-INPUT',
             content: %r{^  jump default_in$},
@@ -191,6 +205,20 @@ describe 'nftables' do
             target:  'nftables-inet-filter-chain-OUTPUT',
             content: %r{^  jump global$},
             order:   '04',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-accept_established_related').with(
+            target:  'nftables-inet-filter-chain-OUTPUT',
+            content: %r{^  ct state established,related accept$},
+            order:   '05',
+          )
+        }
+        it {
+          is_expected.to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-drop_invalid').with(
+            target:  'nftables-inet-filter-chain-OUTPUT',
+            content: %r{^  ct state invalid drop$},
+            order:   '06',
           )
         }
         it {
@@ -319,6 +347,12 @@ describe 'nftables' do
             content: %r{^  jump global$},
             order:   '03',
           )
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-accept_established_related')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-drop_invalid')
         }
         it {
           is_expected.to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-jump_default_fwd').with(
@@ -499,6 +533,33 @@ describe 'nftables' do
         end
 
         it { is_expected.not_to compile }
+      end
+
+      context 'without conntrack rules' do
+        let(:params) do
+          {
+            'in_out_conntrack' => false,
+          }
+        end
+
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-accept_established_related')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-INPUT-rule-drop_invalid')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-accept_established_related')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-OUTPUT-rule-drop_invalid')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-accept_established_related')
+        }
+        it {
+          is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-drop_invalid')
+        }
       end
     end
   end


### PR DESCRIPTION
This patch partly implements the changes discussed in #9 by moving away the conntrack related rules from the `global` chain to `INPUT` and `OUTPUT`. There's a new parameter allowing not having these rules.