### PR TITLE
Move ICMP stuff to separate classes allowing better customisation

### DIFF
--- a/files/config/puppet-inet-filter.nft
+++ b/files/config/puppet-inet-filter.nft
@@ -2,8 +2,4 @@
 
   # something we want for all
   chain global {
-    ip protocol icmp icmp type { destination-unreachable, time-exceeded, parameter-problem } accept
-    ip6 nexthdr ipv6-icmp icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, mld-listener-query, mld-listener-report, mld-listener-done, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, ind-neighbor-solicit, ind-neighbor-advert, mld2-listener-report } accept
-    ip protocol icmp icmp type echo-request limit rate 4/second accept
-    ip6 nexthdr ipv6-icmp icmpv6 type echo-request limit rate 4/second accept
   }

--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -136,6 +136,9 @@ class nftables::inet_filter inherits nftables {
     if $nftables::out_https {
       include nftables::rules::out::https
     }
+    if $nftables::out_icmp {
+      include nftables::rules::out::icmp
+    }
   }
 
   # allow forwarding traffic on bridges
@@ -144,5 +147,8 @@ class nftables::inet_filter inherits nftables {
   # basic ingoing rules
   if $nftables::in_ssh {
     include nftables::rules::ssh
+  }
+  if $nftables::in_icmp {
+    include nftables::rules::icmp
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,8 +23,14 @@
 # @param out_https
 #   Allow outbound to https servers.
 #
+# @param out_icmp
+#   Allow outbound ICMPv4/v6 traffic.
+#
 # @param in_ssh
 #   Allow inbound to ssh servers.
+#
+# @param in_icmp
+#   Allow inbound ICMPv4/v6 traffic.
 #
 # @param log_prefix
 #   String that will be used as prefix when logging packets. It can contain
@@ -44,10 +50,12 @@
 #
 class nftables (
   Boolean $in_ssh                = true,
+  Boolean $in_icmp               = true,
   Boolean $out_ntp               = true,
   Boolean $out_dns               = true,
   Boolean $out_http              = true,
   Boolean $out_https             = true,
+  Boolean $out_icmp              = true,
   Boolean $out_all               = false,
   Boolean $in_out_conntrack      = true,
   Hash $rules                    = {},

--- a/manifests/rules/icmp.pp
+++ b/manifests/rules/icmp.pp
@@ -1,0 +1,37 @@
+class nftables::rules::icmp (
+  Optional[Array[String]] $v4_types = undef,
+  Optional[Array[String]] $v6_types = undef,
+  String $order                     = '10',
+) {
+  if $v4_types {
+    $v4_types.each | String $icmp_type | {
+      nftables::rule{
+        "default_in-accept_icmpv4_${regsubst(split($icmp_type, ' ')[0], '-', '_', 'G')}":
+          content => "ip protocol icmp icmp type ${icmp_type} accept",
+          order   => $order,
+      }
+    }
+  } else {
+    nftables::rule{
+      'default_in-accept_icmpv4':
+        content => 'ip protocol icmp accept',
+        order   => $order,
+      }
+  }
+
+  if $v6_types {
+    $v6_types.each | String $icmp_type | {
+      nftables::rule{
+        "default_in-accept_icmpv6_${regsubst(split($icmp_type, ' ')[0], '-', '_', 'G')}":
+          content => "ip6 nexthdr ipv6-icmp icmpv6 type ${icmp_type} accept",
+          order   => $order,
+      }
+    }
+  } else {
+    nftables::rule{
+      'default_in-accept_icmpv6':
+        content => 'ip6 nexthdr ipv6-icmp accept',
+        order   => $order,
+      }
+  }
+}

--- a/manifests/rules/out/icmp.pp
+++ b/manifests/rules/out/icmp.pp
@@ -1,0 +1,37 @@
+class nftables::rules::out::icmp (
+  Optional[Array[String]] $v4_types = undef,
+  Optional[Array[String]] $v6_types = undef,
+  String $order                     = '10',
+) {
+  if $v4_types {
+    $v4_types.each | String $icmp_type | {
+      nftables::rule{
+        'default_out-accept_icmpv4':
+          content => "ip protocol icmp icmp type ${icmp_type} accept",
+          order   => $order,
+      }
+    }
+  } else {
+    nftables::rule{
+      'default_out-accept_icmpv4':
+        content => 'ip protocol icmp accept',
+        order   => $order,
+      }
+  }
+
+  if $v6_types {
+    $v6_types.each | String $icmp_type | {
+      nftables::rule{
+        'default_out-accept_icmpv6':
+          content => "ip6 nexthdr ipv6-icmp icmpv6 type ${icmp_type} accept",
+          order   => $order,
+      }
+    }
+  } else {
+    nftables::rule{
+      'default_out-accept_icmpv6':
+        content => 'ip6 nexthdr ipv6-icmp accept',
+        order   => $order,
+      }
+  }
+}

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -160,6 +160,9 @@ describe 'nftables' do
             order:   '50-nftables-inet-filter-chain-default_in-rule-ssh-b',
           )
         }
+        it {
+          is_expected.to contain_class('nftables::rules::icmp')
+        }
       end
 
       context 'chain output' do
@@ -307,6 +310,9 @@ describe 'nftables' do
             content: %r{^  tcp dport 443 accept$},
             order:   '50-nftables-inet-filter-chain-default_out-rule-https-b',
           )
+        }
+        it {
+          is_expected.to contain_class('nftables::rules::out::icmp')
         }
       end
 
@@ -551,6 +557,22 @@ describe 'nftables' do
         }
         it {
           is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-FORWARD-rule-drop_invalid')
+        }
+      end
+
+      context 'without ICMP configuration' do
+        let(:params) do
+          {
+            'in_icmp' => false,
+            'out_icmp' => false,
+          }
+        end
+
+        it {
+          is_expected.not_to contain_class('nftables::rules::icmp')
+        }
+        it {
+          is_expected.not_to contain_class('nftables::rules::out::icmp')
         }
       end
     end

--- a/spec/classes/rules/icmp_spec.rb
+++ b/spec/classes/rules/icmp_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe 'nftables::rules::icmp' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'default options' do
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv4').with(
+            content: 'ip protocol icmp accept',
+            order: '10',
+          )
+        }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv6').with(
+            content: 'ip6 nexthdr ipv6-icmp accept',
+            order: '10',
+          )
+        }
+      end
+
+      context 'with custom ICMP types (v4 only)' do
+        let(:params) do
+          {
+            v4_types: ['echo-request limit rate 4/second', 'echo-reply'],
+          }
+        end
+
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv4_echo_request').with(
+            content: 'ip protocol icmp icmp type echo-request limit rate 4/second accept',
+            order: '10',
+          )
+        }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv4_echo_reply').with(
+            content: 'ip protocol icmp icmp type echo-reply accept',
+            order: '10',
+          )
+        }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv6').with(
+            content: 'ip6 nexthdr ipv6-icmp accept',
+            order: '10',
+          )
+        }
+      end
+
+      context 'with custom ICMP types (both v4 and v6)' do
+        let(:params) do
+          {
+            v4_types: ['echo-request limit rate 4/second', 'echo-reply'],
+            v6_types: ['echo-reply', 'nd-router-advert'],
+          }
+        end
+
+        it { is_expected.to compile }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv4_echo_request').with(
+            content: 'ip protocol icmp icmp type echo-request limit rate 4/second accept',
+            order: '10',
+          )
+        }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv4_echo_reply').with(
+            content: 'ip protocol icmp icmp type echo-reply accept',
+            order: '10',
+          )
+        }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv6_echo_reply').with(
+            content: 'ip6 nexthdr ipv6-icmp icmpv6 type echo-reply accept',
+            order: '10',
+          )
+        }
+        it {
+          is_expected.to contain_nftables__rule('default_in-accept_icmpv6_nd_router_advert').with(
+            content: 'ip6 nexthdr ipv6-icmp icmpv6 type nd-router-advert accept',
+            order: '10',
+          )
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a proposal to finish off #9. The patch moves all ICMP traffic management away from the `global` chain, creating specific input and output rules. RHEL8's defaults are followed. 

Users can customise the ICMP4/6 types to allow by providing values via Hiera to `nftables::rules::icmp::v4_types` and other similar parameters. One rule per type is added so it should be possible to add rates as part of the type, for instance:

```yaml
 nftables::rules::icmp::v4_types:
  - "echo-request limit rate 4/second"
```

ICMP rule handling can completely be disabled by tweaking `nftables::in_icmp` and `nftables::out_icmp`.

~~Tests will be added if the proposed interface goes forward.~~

Closes #9 