### PR TITLE
Make masking Service['firewalld'] optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,11 @@
 #   Adds INPUT and OUTPUT rules to allow traffic that's part of an
 #   established connection and also to drop invalid packets.
 #
+# @param firewalld_enable
+#   Configures how the firewalld systemd service unit is enabled. It might be
+#   useful to set this to false if you're externaly removing firewalld from
+#   the system completely.
+#
 class nftables (
   Boolean $in_ssh                = true,
   Boolean $out_ntp               = true,
@@ -55,6 +60,8 @@ class nftables (
   Variant[Boolean[false], Pattern[
     /icmp(v6|x)? type .+|tcp reset/]]
     $reject_with                 = 'icmpx type port-unreachable',
+  Variant[Boolean[false], Enum['mask']]
+    $firewalld_enable            = 'mask',
 ) {
 
   package{'nftables':
@@ -85,7 +92,7 @@ class nftables (
 
   service{'firewalld':
     ensure => stopped,
-    enable => mask,
+    enable => $firewalld_enable,
   }
 
   include nftables::inet_filter

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -89,6 +89,21 @@ describe 'nftables' do
           )
         }
       end
+
+      context 'without masking firewalld' do
+        let(:params) do
+          {
+            'firewalld_enable' => false,
+          }
+        end
+
+        it {
+          is_expected.to contain_service('firewalld').with(
+            ensure: 'stopped',
+            enable: false,
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Users might be completely removing `firewalld` from the system when using this module. Unfortunately masking an unexisting systemd unit leads to errors when applying the catalog:

```
Info: Applying configuration version '1606207933'
Error: Could not disable firewalld:
Error: /Stage[main]/Nftables/Service[firewalld]/enable: change from 'false' to 'mask' failed: Could not disable firewalld:
```

This patch allows module users to disable the unit masking which is enough to get a clean Puppet run if there's no trace of firewalld in the system.