### PR TITLE
Allow disabling default NAT tables and chains

### DIFF
--- a/spec/classes/ip_nat_spec.rb
+++ b/spec/classes/ip_nat_spec.rb
@@ -234,6 +234,22 @@ describe 'nftables' do
           )
         }
       end
+
+      context 'all nat tables disabled' do
+        let(:params) do
+          {
+            'nat' => false,
+          }
+        end
+
+        it { is_expected.not_to contain_class('nftables::ip_nat') }
+        it { is_expected.not_to contain_nftables__config('ip-nat') }
+        it { is_expected.not_to contain_nftables__config('ip6-nat') }
+        it { is_expected.not_to contain_nftables__chain('PREROUTING') }
+        it { is_expected.not_to contain_nftables__chain('POSTROUTING') }
+        it { is_expected.not_to contain_nftables__chain('PREROUTING6') }
+        it { is_expected.not_to contain_nftables__chain('POSTROUTING6') }
+      end
     end
   end
 end

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -17,7 +17,7 @@ describe 'nftables' do
           owner:  'root',
           group:  'root',
           mode:   '0640',
-          source: 'puppet:///modules/nftables/config/puppet.nft',
+          content: %r{flush ruleset},
         )
       }
 
@@ -39,7 +39,7 @@ describe 'nftables' do
           owner:  'root',
           group:  'root',
           mode:   '0640',
-          source: 'puppet:///modules/nftables/config/puppet.nft',
+          content: %r{flush ruleset},
         )
       }
 

--- a/templates/config/puppet.nft.epp
+++ b/templates/config/puppet.nft.epp
@@ -9,5 +9,7 @@ flush ruleset
 
 include "custom-*.nft"
 include "inet-filter.nft"
+<% if $nat { -%>
 include "ip-nat.nft"
 include "ip6-nat.nft"
+<% } -%>


### PR DESCRIPTION
This patch adds a parameter to the main interface to prevent the module from including `nftables::ip_nat` and hence from configuring any of the default tables and chains dedicated to processing NATed traffic.

Closes #23.