### PR TITLE
Allow sourcing sets from Hiera

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,9 @@
 # @param nat
 #   Add default tables and chains to process NAT traffic.
 #
+# @param sets
+#   Allows sourcing set definitions directly from Hiera.
+#
 # @param log_prefix
 #   String that will be used as prefix when logging packets. It can contain
 #   two variables using standard sprintf() string-formatting:
@@ -68,6 +71,7 @@ class nftables (
   Boolean $in_out_conntrack      = true,
   Boolean $nat                   = true,
   Hash $rules                    = {},
+  Hash $sets                     = {},
   String $log_prefix             = '[nftables] %<chain>s %<comment>s',
   Variant[Boolean[false], Pattern[
     /icmp(v6|x)? type .+|tcp reset/]]
@@ -142,6 +146,14 @@ class nftables (
   # inject custom rules e.g. from hiera
   $rules.each |$n,$v| {
     nftables::rule{
+      $n:
+        * => $v
+    }
+  }
+
+  # inject custom sets e.g. from hiera
+  $sets.each |$n,$v| {
+    nftables::set{
       $n:
         * => $v
     }

--- a/spec/classes/nftables_spec.rb
+++ b/spec/classes/nftables_spec.rb
@@ -121,6 +121,38 @@ describe 'nftables' do
         }
       end
 
+      context 'with custom sets' do
+        let(:params) do
+          {
+            sets: {
+              'testset1' => {
+                type: 'ipv4_addr',
+                gc_interval: 2,
+              },
+              'testset2' => {
+                type: 'ipv6_addr',
+                elements: ['2a02:62:c601::dead:beef'],
+              },
+            },
+          }
+        end
+
+        it {
+          is_expected.to contain_nftables__set('testset1').with(
+            type: 'ipv4_addr',
+            gc_interval: 2,
+            table: 'inet-filter',
+          )
+        }
+        it {
+          is_expected.to contain_nftables__set('testset2').with(
+            type: 'ipv6_addr',
+            elements: ['2a02:62:c601::dead:beef'],
+            table: 'inet-filter',
+          )
+        }
+      end
+
       context 'without masking firewalld' do
         let(:params) do
           {


### PR DESCRIPTION
The modification allows users to source set definitions in bulk via Hiera, similarly to how  ``nftables::rules`` works.

Closes #24.