### PR TITLE
Do not test nftables::rules repeatadly

### DIFF
--- a/spec/classes/bridges_spec.rb
+++ b/spec/classes/bridges_spec.rb
@@ -5,49 +5,37 @@ describe 'nftables' do
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts }
+      context 'with bridge interfaces br0 and br1-2' do
+        let(:facts) do
+          os_facts.merge(
+            networking:
+              { interfaces:
+                {
+                  'lo' => {},
+                  'br0' => {},
+                  'br1-2' => {},
+                } },
+          )
+        end
 
-      it { is_expected.to compile }
+        it { is_expected.to compile }
+        it { is_expected.not_to contain_nftables__rule('default_fwd-bridge_lo_lo') }
 
-      it {
-        is_expected.to contain_concat('nftables-inet-filter-chain-default_fwd').with(
-          path:           '/etc/nftables/puppet-preflight/inet-filter-chain-default_fwd.nft',
-          owner:          'root',
-          group:          'root',
-          mode:           '0640',
-          ensure_newline: true,
-        )
-      }
-      it {
-        is_expected.to contain_concat__fragment('nftables-inet-filter-chain-default_fwd-header').with(
-          target:  'nftables-inet-filter-chain-default_fwd',
-          content: %r{^chain default_fwd \{$},
-          order:   '00',
-        )
-      }
-      it {
-        is_expected.to contain_concat__fragment('nftables-inet-filter-chain-default_fwd-rule-bridge_br0_br0').with(
-          target:  'nftables-inet-filter-chain-default_fwd',
-          content: %r{^  iifname br0 oifname br0 accept$},
-          order:   '08-nftables-inet-filter-chain-default_fwd-rule-bridge_br0_br0-b',
-        )
-      }
-      it {
-        is_expected.to contain_concat__fragment('nftables-inet-filter-chain-default_fwd-rule-bridge_br1_br1').with(
-          target:  'nftables-inet-filter-chain-default_fwd',
-          content: %r{^  iifname br1 oifname br1 accept$},
-          order:   '08-nftables-inet-filter-chain-default_fwd-rule-bridge_br1_br1-b',
-        )
-      }
-      it { is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-default_fwd-bridge_br0_br1') }
-      it { is_expected.not_to contain_concat__fragment('nftables-inet-filter-chain-default_fwd-bridge_br1_br0') }
-      it {
-        is_expected.to contain_concat__fragment('nftables-inet-filter-chain-default_fwd-footer').with(
-          target:  'nftables-inet-filter-chain-default_fwd',
-          content: %r{^\}$},
-          order:   '99',
-        )
-      }
+        it {
+          is_expected.to contain_nftables__rule('default_fwd-bridge_br0_br0').with(
+            order: '08',
+            content: 'iifname br0 oifname br0 accept',
+          )
+        }
+
+        it { is_expected.to contain_nftables__rule('default_fwd-bridge_br1_br1') }
+        it {
+          is_expected.to contain_nftables__rule('default_fwd-bridge_br1_br1').with(
+            order: '08',
+            content: 'iifname br1 oifname br1 accept',
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Rather than testing the contents of nftable::rules just test
that nftables::rules instance is correct.

The existing test for the define nftables::rules is enough.

Motivation here is to make changes to nftables::rules easier to handle
down the line.