### PR TITLE
Enable conntrack in FORWARD

### DIFF
--- a/manifests/inet_filter.pp
+++ b/manifests/inet_filter.pp
@@ -115,13 +115,23 @@ class nftables::inet_filter inherits nftables {
       content => 'jump global';
     'FORWARD-log_discarded':
       order   => '97',
-      content => sprintf($_reject_rule, { 'chain' => 'FORWARD' }),
+      content => sprintf($_reject_rule, { 'chain' => 'FORWARD' });
   }
   if $nftables::reject_with {
     nftables::rule{
       'FORWARD-reject':
         order   => '98',
         content => "reject with ${$nftables::reject_with}";
+    }
+  }
+  if $nftables::fwd_conntrack {
+    nftables::rule{
+      'FORWARD-accept_established_related':
+        order   => '05',
+        content => 'ct state established,related accept';
+      'FORWARD-drop_invalid':
+        order   => '06',
+        content => 'ct state invalid drop';
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,10 @@
 #   Adds INPUT and OUTPUT rules to allow traffic that's part of an
 #   established connection and also to drop invalid packets.
 #
+# @param fwd_conntrack
+#   Adds FORWARD rules to allow traffic that's part of an
+#   established connection and also to drop invalid packets.
+#
 # @param firewalld_enable
 #   Configures how the firewalld systemd service unit is enabled. It might be
 #   useful to set this to false if you're externaly removing firewalld from
@@ -74,6 +78,7 @@ class nftables (
   Boolean $out_icmp              = true,
   Boolean $out_all               = false,
   Boolean $in_out_conntrack      = true,
+  Boolean $fwd_conntrack         = false,
   Boolean $nat                   = true,
   Hash $rules                    = {},
   Hash $sets                     = {},

--- a/spec/classes/inet_filter_spec.rb
+++ b/spec/classes/inet_filter_spec.rb
@@ -597,6 +597,7 @@ describe 'nftables' do
         let(:params) do
           {
             'in_out_conntrack' => false,
+            'fwd_conntrack'    => false,
           }
         end
 


### PR DESCRIPTION
This PR will enable conntrack for forwarding packages. This is mostly used for router traffic.
This extends #14.