### PR TITLE
New parameter noflush_tables to selectivly skip flush

### DIFF
--- a/files/systemd/puppet_nft.conf
+++ b/files/systemd/puppet_nft.conf
@@ -1,7 +1,0 @@
-# Specify directory to look for relative includes
-[Service]
-ExecStart=
-ExecStart=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
-ExecReload=
-ExecReload=/sbin/nft -I /etc/nftables/puppet 'flush ruleset; include "/etc/sysconfig/nftables.conf";'
-

--- a/lib/facter/nftables.rb
+++ b/lib/facter/nftables.rb
@@ -1,0 +1,21 @@
+#
+# Produce an array of nftables.
+# nft list tables
+# table inet filter
+# table ip nat
+# table ip6 nat
+# table inet f2b-table
+#
+Facter.add(:nftables) do
+  @nft_cmd = Facter::Util::Resolution.which('nft')
+  confine { @nft_cmd }
+
+  setcode do
+    tables = []
+    table_result = Facter::Core::Execution.execute(%(#{@nft_cmd} list tables))
+    table_result.each_line do |line|
+      tables.push(line.split(' ')[1, 2].join('-'))
+    end
+    { 'tables' => tables }
+  end
+end

--- a/spec/unit/facter/nftables_spec.rb
+++ b/spec/unit/facter/nftables_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'nftables' do
+  before(:each) do
+    Facter.clear
+    Process.stubs(:uid).returns(0)
+    Facter::Util::Resolution.stubs(:which).with('nft').returns('/usr/sbin/nft')
+    Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nft list tables').returns(nft_result)
+  end
+
+  context 'nft rules present' do
+    let(:nft_result) { "table inet firewalld\ntable ip firewalld\n" }
+
+    it 'returns valid tables' do
+      expect(Facter.fact('nftables').value).to eq('tables' => ['inet-firewalld', 'ip-firewalld'])
+    end
+  end
+
+  context 'nft fails' do
+    let(:nft_result) { :failed }
+
+    it 'does not return a fact' do
+      Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nft list tables', on_fail: :failed).returns(:failed)
+
+      expect(Facter.fact('nftables').value).to be_nil
+    end
+  end
+end

--- a/templates/config/puppet.nft.epp
+++ b/templates/config/puppet.nft.epp
@@ -1,3 +1,16 @@
+<%- |
+  Boolean $nat,
+  Optional[Array[String[1],1]] $noflush = undef,
+|-%>
+<%-
+if $noflush and $facts['nftables'] and $facts['nftables']['tables'] {
+ $_flush_command = $facts['nftables']['tables'].filter |$_tab| { ! ($_tab in $noflush) }.map |$_table| {
+   "flush table ${regsubst($_table,'-',' ')}"
+ }
+} else {
+ $_flush_command = ['flush ruleset']
+}
+-%>
 # puppet-preflight.nft is only used by puppet for validating new configs
 # puppet.nft is real configuration that the nftables services uses.
 # To process either the -I flag must be specified.
@@ -5,7 +18,7 @@
 # nft -c -I /etc/nftables/puppet-preflight -f /etc/nftables/puppet-preflight.nft
 
 # drop any existing nftables ruleset
-flush ruleset
+<%= $_flush_command.join('; ') %>
 
 include "custom-*.nft"
 include "inet-filter.nft"

--- a/templates/systemd/puppet_nft.conf.epp
+++ b/templates/systemd/puppet_nft.conf.epp
@@ -1,0 +1,19 @@
+<%- |
+  Optional[Array[String[1]]] $noflush = undef,
+| -%>
+<%-
+if $noflush and $facts['nftables'] and $facts['nftables']['tables'] {
+ $_flush_command = $facts['nftables']['tables'].filter |$_tab| { !( $_tab in $noflush) }.map |$_table| {
+     "flush table ${regsubst($_table,'-',' ')}"
+ }
+} else {
+ $_flush_command = ['flush ruleset']
+}
+-%>
+# Specify directory to look for relative includes
+[Service]
+ExecStart=
+ExecStart=/sbin/nft -I /etc/nftables/puppet -f /etc/sysconfig/nftables.conf
+ExecReload=
+ExecReload=/sbin/nft -I /etc/nftables/puppet '<%= $_flush_command.join('; ') %>; include "/etc/sysconfig/nftables.conf";'
+


### PR DESCRIPTION
Introduces a new structured fact nftables

```yaml
nftables:
  tables:
    - inet-filter
    - ip-nat
    - ip6-nat
    - inet-f2b-table
```

By default the nft script will continue to contain `nft flush ruleset`

If noflush_tables is specified e.g.

```puppet
class{nftables:
  noflush_tables => ['inet-f2b-table'],
}
```
the results script will explicity flush the other tables only.
i.e.

```
flush table inet filter
flush table ip nat
flush table ip6 nat
```

Motivation here is to allow a maintence of chain to managed by something else.
This example for fail2ban but could be docker, ...